### PR TITLE
grasp-visualisation

### DIFF
--- a/Train.py
+++ b/Train.py
@@ -2,6 +2,7 @@ import math
 import os
 import random
 
+import numpy
 import pandas
 import torch
 import pandas as pd
@@ -109,23 +110,37 @@ loss_fn = nn.MSELoss()
 optimizer = Adam(model.parameters(), lr=0.001)
 
 
+def rotate(origin, point, angle):
+    ox, oy = origin
+    px, py = point
+
+    qx = ox + math.cos(angle) * (px - ox) - math.sin(angle) * (py - oy)
+    qy = oy + math.sin(angle) * (px - ox) + math.cos(angle) * (py - oy)
+    return qx, qy
+
+
 def showImageGrasp(image, x, y, t, h, w):
     reshapedImage = image.reshape(3, 1024, 1024).permute(2, 1, 0)
     halfHeight = h / 2
     halfWidth = w / 2
+
+    topLeftCorner = rotate([x, y], [x - halfWidth, y + halfHeight], t)
+    topRightCorner = rotate([x,y], [x+halfWidth, y+halfHeight], t)
+    bottomRightCorner = rotate([x, y], [x + halfWidth, y - halfHeight], t)
+    bottomLeftCorner = rotate([x,y], [x-halfWidth, y-halfHeight], t)
 
     print("PERMUTED IMAGE SHAPE", reshapedImage.shape)
     plt.imshow(reshapedImage)
     # plot the center point
     plt.plot([x], [y], 'x')
     # Top left to top right
-    plt.plot([x - halfWidth, x + halfWidth], [y + halfHeight, y + halfHeight])
+    plt.plot([topLeftCorner[0], topRightCorner[0]], [topLeftCorner[1], topRightCorner[1]])
     # Top left to bottom left
-    plt.plot([x - halfWidth, x - halfWidth], [y + halfHeight, y - halfHeight])
+    plt.plot([topLeftCorner[0], bottomLeftCorner[0]], [topLeftCorner[1], bottomLeftCorner[1]])
     # Top right to bottom right
-    plt.plot([x + halfWidth, x + halfWidth], [y + halfHeight, y - halfHeight])
+    plt.plot([topRightCorner[0], bottomRightCorner[0]], [topRightCorner[1], bottomRightCorner[1]])
     # Bottom left to bottom right
-    plt.plot([x - halfWidth, x + halfWidth], [y - halfHeight, y - halfHeight])
+    plt.plot([bottomLeftCorner[0], bottomRightCorner[0]], [bottomLeftCorner[1], bottomRightCorner[1]])
     plt.show()
     return
 

--- a/Train.py
+++ b/Train.py
@@ -1,3 +1,4 @@
+import math
 import os
 import random
 
@@ -11,8 +12,10 @@ from torch.utils.data import DataLoader, Dataset
 from torchvision import datasets, transforms
 import skimage
 import cv2
+import matplotlib.pyplot as plt
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 
 # Dataset class for retrieving data from resource files.
 class GraspDataset(Dataset):
@@ -105,12 +108,35 @@ model = NeuralNetwork()
 loss_fn = nn.MSELoss()
 optimizer = Adam(model.parameters(), lr=0.001)
 
+
+def showImageGrasp(image, x, y, t, h, w):
+    reshapedImage = image.reshape(3, 1024, 1024).permute(2, 1, 0)
+    halfHeight = h / 2
+    halfWidth = w / 2
+
+    print("PERMUTED IMAGE SHAPE", reshapedImage.shape)
+    plt.imshow(reshapedImage)
+    # plot the center point
+    plt.plot([x], [y], 'x')
+    # Top left to top right
+    plt.plot([x - halfWidth, x + halfWidth], [y + halfHeight, y + halfHeight])
+    # Top left to bottom left
+    plt.plot([x - halfWidth, x - halfWidth], [y + halfHeight, y - halfHeight])
+    # Top right to bottom right
+    plt.plot([x + halfWidth, x + halfWidth], [y + halfHeight, y - halfHeight])
+    # Bottom left to bottom right
+    plt.plot([x - halfWidth, x + halfWidth], [y - halfHeight, y - halfHeight])
+    plt.show()
+    return
+
+
 # Training Loop
 for epoch in range(5):  # loop over the dataset multiple times
     running_loss = 0.0
     for i, data in enumerate(trainLoader, 0):
         # get the inputs; data is a list of [inputs, labels]
         image, x, y, t, h, w = data
+        print("IMAGE SHAPE", image.shape)
 
         optimizer.zero_grad()
 
@@ -119,7 +145,7 @@ for epoch in range(5):  # loop over the dataset multiple times
         targetList = [x, y, t, h, w]
         targetTensor = torch.FloatTensor(targetList)
         targetTensor = targetTensor.unsqueeze(0)
-
+        showImageGrasp(image, x, y, t, h, w)
         print("OUTPUT_TENSOR: ", outputs.data)
         print("TARGET_TENSOR: ", targetTensor)
 


### PR DESCRIPTION
### Summary

Introduced a function `showImageGrasp` with `(image, x, y, t, h, w)` as params.

We reshape the provided image from `(1,3,1024,1024)` to `(3,1024,1024)` then `permuted` it to swap the channels for `plt.imshow()`.
Resulting image is of shape `(1024,1024,3)`

Rotation is calculated with `rotate(origin, point, angle)` where the coordinates supplied in `point` are rotated by `angle` around `origin`

Coordinates for the grasp rectangle corners are calculated with:
```
    topLeftCorner = rotate([x, y], [x - halfWidth, y + halfHeight], t)
    topRightCorner = rotate([x,y], [x+halfWidth, y+halfHeight], t)
    bottomRightCorner = rotate([x, y], [x + halfWidth, y - halfHeight], t)
    bottomLeftCorner = rotate([x,y], [x-halfWidth, y-halfHeight], t)
```

and plotted along with the center point:
```
    plt.imshow(reshapedImage)
    # plot the center point
    plt.plot([x], [y], 'x')
    # Top left to top right
    plt.plot([topLeftCorner[0], topRightCorner[0]], [topLeftCorner[1], topRightCorner[1]])
    # Top left to bottom left
    plt.plot([topLeftCorner[0], bottomLeftCorner[0]], [topLeftCorner[1], bottomLeftCorner[1]])
    # Top right to bottom right
    plt.plot([topRightCorner[0], bottomRightCorner[0]], [topRightCorner[1], bottomRightCorner[1]])
    # Bottom left to bottom right
    plt.plot([bottomLeftCorner[0], bottomRightCorner[0]], [bottomLeftCorner[1], bottomRightCorner[1]])
    plt.show()
```

Resulting in the following:
![image](https://user-images.githubusercontent.com/58849535/160404750-6a5d86c0-8c24-4792-a1cc-c9712ae9081f.png)

Currently images are shown per training iteration. Probably should re-factor this to show a grid of images at the end of training. 